### PR TITLE
Fix crate name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Add the following to your `Cargo.toml`.
 
 ```
-serial-enumerate = "0.1.0"
+serial_enumerate = "0.1.0"
 ```
 
 ## Example


### PR DESCRIPTION
The actual crate name registered on crates.io is `serial_enumerate`, right?